### PR TITLE
Fix some assignments to undeclared variables that cluttered the global namespace

### DIFF
--- a/source/CubicVR.Mesh.js
+++ b/source/CubicVR.Mesh.js
@@ -115,6 +115,7 @@ CubicVR.RegisterModule("Mesh", function (base) {
         },
 
         setFaceMaterial: function (mat, facenum) {
+            var mat_id;
             if (typeof (mat) == 'number') {
                 mat_id = mat;
             } else {
@@ -762,7 +763,8 @@ CubicVR.RegisterModule("Mesh", function (base) {
               numPoints,
               ofs,
               ptIdx,
-              i, iMax;
+              i, iMax,
+              k, kMax;
 
             if (compileMap.points && doVertex) {
                 numPoints = compileMap.points.length;

--- a/source/CubicVR.Octree.js
+++ b/source/CubicVR.Octree.js
@@ -99,7 +99,7 @@ function Octree(size, max_depth, root, position, child_index) {
   aabbMath.engulf(bbox, [position[0] - s, position[1] - s, position[2] - s]);
   this._debug_visible = false;
 } //Octree::Constructor
-Array_remove = function(arr, from, to) {
+var Array_remove = function(arr, from, to) {
   var rest = arr.slice((to || from) + 1 || arr.length);
   arr.length = from < 0 ? arr.length + from : from;
   return arr.push.apply(arr, rest);

--- a/source/CubicVR.Renderer.js
+++ b/source/CubicVR.Renderer.js
@@ -82,7 +82,7 @@ CubicVR.RegisterModule("Renderer",function(base){
 
             for (subcount = 0; subcount < numLights; )
             {
-              nLights = numLights-subcount;
+              var nLights = numLights-subcount;
               if (nLights>base.MAX_LIGHTS) { 
                 nLights=base.MAX_LIGHTS;
               }


### PR DESCRIPTION
Some tiny things, but they were enough to mix up ammo.js because it can't run in a closure ;)
