### PR TITLE
bugfix - add missing return to isActive

### DIFF
--- a/source/CubicVR.ScenePhysics.js
+++ b/source/CubicVR.ScenePhysics.js
@@ -549,7 +549,7 @@ CubicVR.RegisterModule("ScenePhysics",function(base) {
     },
     isActive: function() {
       if (this.body) {
-        this.body.isActive();
+        return this.body.isActive();
       } else {
         return false;
       }


### PR DESCRIPTION
isActive is missing a return statement, leading to returning undefined most of the time.
